### PR TITLE
Parsing improvements

### DIFF
--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -39,6 +39,23 @@ func TestParseAdstxt(t *testing.T) {
 			},
 		},
 		{
+			txt: "\n\nexample.com, 1, direct, TAG ID1; COMMENT1\n\nexample.org , \t2 , \treseller , \tTAG ID2 ; \tCOMMENT2\n\nfoo=bar",
+			expected: []adstxt.Record{
+				{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "1",
+					AccountType:        adstxt.AccountDirect,
+					AuthorityID:        "TAG ID1",
+				},
+				{
+					ExchangeDomain:     "example.org",
+					PublisherAccountID: "2",
+					AccountType:        adstxt.AccountReseller,
+					AuthorityID:        "TAG ID2",
+				},
+			},
+		},
+		{
 			txt: "# comment out\nexample.com,1,DIRECT",
 			expected: []adstxt.Record{
 				{

--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -39,7 +39,7 @@ func TestParseAdstxt(t *testing.T) {
 			},
 		},
 		{
-			txt: "\n\nexample.com, 1, direct, TAG ID1; COMMENT1\n\nexample.org , \t2 , \treseller , \tTAG ID2 ; \tCOMMENT2\n\nfoo=bar",
+			txt: "\n\nEXAMPLE.COM, 1, direct, TAG ID1; COMMENT1\n\nEXAMPLE.ORG , \t2 , \treseller , \tTAG ID2 ; \tCOMMENT2\n\nfoo=bar",
 			expected: []adstxt.Record{
 				{
 					ExchangeDomain:     "example.com",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/suzuken/go-adstxt
+
+go 1.14

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,100 @@
+package adstxt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// Parser is an iterative ads.txt parser
+type Parser struct {
+	scanner *bufio.Scanner
+}
+
+// NewParser returns a Parser
+func NewParser(r io.Reader) *Parser {
+	return &Parser{bufio.NewScanner(r)}
+}
+
+// Parse returns a *Record or an error
+func (p *Parser) Parse() (*Record, error) {
+	// scans for the first valid row or returns an error otherwise
+	for p.scanner.Scan() {
+		text := p.scanner.Text()
+
+		// blank line
+		if len(text) == 0 {
+			continue
+		}
+
+		// comment out
+		if []rune(text)[0] == '#' {
+			continue
+		}
+
+		// returns when either is non-nil
+		r, err := parseRow(text)
+		if r != nil || err != nil {
+			return r, err
+		}
+	}
+
+	if err := p.scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, io.EOF
+}
+
+func parseAccountType(s string) AccountType {
+	switch strings.ToUpper(s) {
+	case "DIRECT":
+		return AccountDirect
+	case "RESELLER":
+		return AccountReseller
+	default:
+		// NOTE or should be error ?
+		return AccountOther
+	}
+}
+
+var leadingBlankRe = regexp.MustCompile(`\A[\s\t]+`)
+var trailingBlankRe = regexp.MustCompile(`[\s\t]+\z`)
+
+func normalize(s string) string {
+	// sanitize blank characters
+	s = leadingBlankRe.ReplaceAllString(s, "")
+	s = trailingBlankRe.ReplaceAllString(s, "")
+	return s
+}
+
+func parseRow(row string) (*Record, error) {
+	// dropping extension field
+	if idx := strings.Index(row, ";"); idx != -1 {
+		row = row[0:idx]
+	}
+
+	fields := strings.Split(row, ",")
+
+	// if the first field contains "=", then the row is for variable declaration
+	if strings.Index(fields[0], "=") != -1 {
+		return nil, nil
+	}
+
+	if l := len(fields); l != 3 && l != 4 {
+		return nil, fmt.Errorf("ads.txt has fields length is incorrect.: %s", row)
+	}
+
+	// otherwise the row is valid
+	var r Record
+	r.ExchangeDomain = strings.ToLower(normalize(fields[0]))
+	r.PublisherAccountID = normalize(fields[1])
+	r.AccountType = parseAccountType(normalize(fields[2]))
+	// AuthorityID is optional
+	if len(fields) >= 4 {
+		r.AuthorityID = normalize(fields[3])
+	}
+	return &r, nil
+}


### PR DESCRIPTION
Various parser improvements without API change.

* separate parser
* skip blank lines
* drop extension field (the optional and final field separated by `;`)
* trim fields by dropping leading and trailing blank chars
* fix variable declaration row handling (as it can be any `key=value` pairs)
* make it go module ready