### PR TITLE
follow 3.4.1 comments spec

### DIFF
--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -56,7 +56,7 @@ func TestParseAdstxt(t *testing.T) {
 			},
 		},
 		{
-			txt: "# comment out\nexample.com,1,DIRECT",
+			txt: "# comment.out,comment-publisher,DIRECT\nexample.com,1,DIRECT",
 			expected: []adstxt.Record{
 				{
 					ExchangeDomain:     "example.com",

--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -65,15 +65,32 @@ func TestParseAdstxt(t *testing.T) {
 				},
 			},
 		},
+		{
+			txt: "example.com,1,DIRECT# trailing comment\nexample.com,2,RESELLER###trailing comment",
+			expected: []adstxt.Record{
+				{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "1",
+					AccountType:        adstxt.AccountDirect,
+				},
+				{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "2",
+					AccountType:        adstxt.AccountReseller,
+				},
+			},
+		},
 	}
 
-	for i, c := range cases {
-		record, err := adstxt.Parse(strings.NewReader(c.txt))
-		if err != nil {
-			t.Errorf("(#%d) parse ads.txt failed: %s", i, err)
-		}
-		if !reflect.DeepEqual(c.expected, record) {
-			t.Errorf("want %v, got %v", c.expected, record)
-		}
+	for _, c := range cases {
+		t.Run(c.txt, func(t *testing.T) {
+			record, err := adstxt.Parse(strings.NewReader(c.txt))
+			if err != nil {
+				t.Errorf("parse ads.txt failed: %s", err)
+			}
+			if !reflect.DeepEqual(c.expected, record) {
+				t.Errorf("want %v, got %v", c.expected, record)
+			}
+		})
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -24,13 +24,13 @@ func (p *Parser) Parse() (*Record, error) {
 	for p.scanner.Scan() {
 		text := p.scanner.Text()
 
-		// blank line
-		if len(text) == 0 {
-			continue
+		// remove comment
+		if idx := strings.IndexRune(text, '#'); idx >= 0 {
+			text = text[0:idx]
 		}
 
-		// comment out
-		if []rune(text)[0] == '#' {
+		// blank line
+		if len(text) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
IAB spec defines comments as:

> 3.4.1 COMMENTS
> Comment are denoted by the character "#". Any line containing "#" should inform the data consumer to ignore the data after the "#" character to the end of the line.