### PR TITLE
Fix error with space only row

### DIFF
--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -80,6 +80,21 @@ func TestParseAdstxt(t *testing.T) {
 				},
 			},
 		},
+		{
+			txt: "example.com,1,DIRECT\n      \nexample.com,2,RESELLER",
+			expected: []adstxt.Record{
+				{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "1",
+					AccountType:        adstxt.AccountDirect,
+				},
+				{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "2",
+					AccountType:        adstxt.AccountReseller,
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/parser.go
+++ b/parser.go
@@ -22,7 +22,7 @@ func NewParser(r io.Reader) *Parser {
 func (p *Parser) Parse() (*Record, error) {
 	// scans for the first valid row or returns an error otherwise
 	for p.scanner.Scan() {
-		text := p.scanner.Text()
+		text := strings.TrimSpace(p.scanner.Text())
 
 		// remove comment
 		if idx := strings.IndexRune(text, '#'); idx >= 0 {


### PR DESCRIPTION
スペースだけの行があるとパースに失敗してしまうのでパースする前にtrimする

スペースのみの行はblank判定されないので
https://github.com/suzuken/go-adstxt/blob/master/parser.go#L86
ここでlengthが1になって`ads.txt has fields length is incorrect.`を吐いてしまう