### PR TITLE
Parse and return variables

### DIFF
--- a/adstxt.go
+++ b/adstxt.go
@@ -6,31 +6,6 @@ import (
 	"net/http"
 )
 
-// Record is ads.txt data field defined in iab.
-type Record struct {
-	// ExchangeDomain is domain name of the advertising system
-	ExchangeDomain string
-
-	// PublisherAccountID is the identifier associated with the seller
-	// or reseller account within the advertising system.
-	PublisherAccountID string
-
-	// AccountType is an enumeration of the type of account.
-	AccountType AccountType
-
-	// AuthorityID is an ID that uniquely identifies the advertising system
-	// within a certification authority.
-	AuthorityID string
-}
-
-const (
-	AccountDirect AccountType = iota
-	AccountReseller
-	AccountOther
-)
-
-type AccountType int
-
 func Get(rawurl string) ([]Record, error) {
 	resp, err := http.Get(rawurl)
 	if err != nil {

--- a/adstxt.go
+++ b/adstxt.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 )
 
+// Deprecated: to be removed
 func Get(rawurl string) ([]Record, error) {
 	resp, err := http.Get(rawurl)
 	if err != nil {
@@ -15,6 +16,7 @@ func Get(rawurl string) ([]Record, error) {
 	return Parse(resp.Body)
 }
 
+// Deprecated: use ParseRows instead.
 func Parse(in io.Reader) ([]Record, error) {
 	records := make([]Record, 0)
 	p := NewParser(in)
@@ -34,4 +36,24 @@ LOOP:
 	}
 
 	return records, nil
+}
+
+func ParseRows(in io.Reader) ([]Row, error) {
+	rows := make([]Row, 0)
+	p := NewParser(in)
+
+	for {
+		row, err := p.ParseRow()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if row != nil {
+			rows = append(rows, *row)
+		}
+	}
+
+	return rows, nil
 }

--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -1,7 +1,6 @@
 package adstxt_test
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -104,8 +103,8 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Errorf("parse ads.txt failed: %s", err)
 			}
-			if !reflect.DeepEqual(c.expected, record) {
-				t.Errorf("want %v, got %v", c.expected, record)
+			if d := cmp.Diff(c.expected, record); d != "" {
+				t.Errorf("mismatch (-want +got):\n%s", d)
 			}
 		})
 	}

--- a/adstxt_test.go
+++ b/adstxt_test.go
@@ -138,7 +138,6 @@ func TestParseRows(t *testing.T) {
 					},
 				},
 				{
-					Record:   nil,
 					Variable: &adstxt.Variable{Key: "foo", Value: "bar"},
 				},
 			},
@@ -152,10 +151,8 @@ func TestParseRows(t *testing.T) {
 						PublisherAccountID: "2",
 						AccountType:        adstxt.AccountReseller,
 					},
-					Variable: nil,
 				},
 				{
-					Record:   nil,
 					Variable: &adstxt.Variable{Key: "baz", Value: "qux"},
 				},
 			},
@@ -169,10 +166,8 @@ func TestParseRows(t *testing.T) {
 						PublisherAccountID: "1",
 						AccountType:        adstxt.AccountDirect,
 					},
-					Variable: nil,
 				},
 				{
-					Record:   nil,
 					Variable: &adstxt.Variable{Key: "foo", Value: "bar"},
 				},
 				{
@@ -181,7 +176,6 @@ func TestParseRows(t *testing.T) {
 						PublisherAccountID: "2",
 						AccountType:        adstxt.AccountReseller,
 					},
-					Variable: nil,
 				},
 			},
 		},
@@ -189,7 +183,6 @@ func TestParseRows(t *testing.T) {
 			txt: "key=value\nexample.com,1,DIRECT\nkey2=value2",
 			expected: []adstxt.Row{
 				{
-					Record:   nil,
 					Variable: &adstxt.Variable{Key: "key", Value: "value"},
 				},
 				{
@@ -198,10 +191,8 @@ func TestParseRows(t *testing.T) {
 						PublisherAccountID: "1",
 						AccountType:        adstxt.AccountDirect,
 					},
-					Variable: nil,
 				},
 				{
-					Record:   nil,
 					Variable: &adstxt.Variable{Key: "key2", Value: "value2"},
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/suzuken/go-adstxt
 
-go 1.14
+go 1.21
+
+require github.com/google/go-cmp v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/suzuken/go-adstxt
 
 go 1.21
 
-require github.com/google/go-cmp v0.7.0 // indirect
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/parser.go
+++ b/parser.go
@@ -43,7 +43,7 @@ func (p *Parser) Parse() (*Record, error) {
 }
 
 // ParseRow returns a Row
-func (p *Parser) ParseRow() (Row, error) {
+func (p *Parser) ParseRow() (*Row, error) {
 	// scans for the first valid row or returns an error otherwise
 	for p.scanner.Scan() {
 		text := normalizeRow(p.scanner.Text())

--- a/parser.go
+++ b/parser.go
@@ -17,7 +17,7 @@ func NewParser(r io.Reader) *Parser {
 }
 
 // Parse returns a *Record or an error
-// Deprecated: use ParseRow instead.
+// Deprecated: use ParseRow instead to support both records and variables.
 func (p *Parser) Parse() (*Record, error) {
 	// scans for the first valid row or returns an error otherwise
 	for p.scanner.Scan() {

--- a/parser.go
+++ b/parser.go
@@ -2,9 +2,7 @@ package adstxt
 
 import (
 	"bufio"
-	"fmt"
 	"io"
-	"regexp"
 	"strings"
 )
 
@@ -19,15 +17,11 @@ func NewParser(r io.Reader) *Parser {
 }
 
 // Parse returns a *Record or an error
+// Deprecated: use ParseRow instead.
 func (p *Parser) Parse() (*Record, error) {
 	// scans for the first valid row or returns an error otherwise
 	for p.scanner.Scan() {
-		text := strings.TrimSpace(p.scanner.Text())
-
-		// remove comment
-		if idx := strings.IndexRune(text, '#'); idx >= 0 {
-			text = text[0:idx]
-		}
+		text := normalizeRow(p.scanner.Text())
 
 		// blank line
 		if len(text) == 0 {
@@ -35,7 +29,7 @@ func (p *Parser) Parse() (*Record, error) {
 		}
 
 		// returns when either is non-nil
-		r, err := parseRow(text)
+		r, err := parseRecord(text)
 		if r != nil || err != nil {
 			return r, err
 		}
@@ -48,53 +42,38 @@ func (p *Parser) Parse() (*Record, error) {
 	return nil, io.EOF
 }
 
-func parseAccountType(s string) AccountType {
-	switch strings.ToUpper(s) {
-	case "DIRECT":
-		return AccountDirect
-	case "RESELLER":
-		return AccountReseller
-	default:
-		// NOTE or should be error ?
-		return AccountOther
+// ParseRow returns a Row
+func (p *Parser) ParseRow() (Row, error) {
+	// scans for the first valid row or returns an error otherwise
+	for p.scanner.Scan() {
+		text := normalizeRow(p.scanner.Text())
+
+		// blank line
+		if len(text) == 0 {
+			continue
+		}
+
+		r, err := parseRow(text)
+		if r != nil || err != nil {
+			return r, err
+		}
+
 	}
+
+	if err := p.scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, io.EOF
 }
 
-var leadingBlankRe = regexp.MustCompile(`\A[\s\t]+`)
-var trailingBlankRe = regexp.MustCompile(`[\s\t]+\z`)
+func normalizeRow(s string) string {
+	text := strings.TrimSpace(s)
 
-func normalize(s string) string {
-	// sanitize blank characters
-	s = leadingBlankRe.ReplaceAllString(s, "")
-	s = trailingBlankRe.ReplaceAllString(s, "")
-	return s
-}
-
-func parseRow(row string) (*Record, error) {
-	// dropping extension field
-	if idx := strings.Index(row, ";"); idx != -1 {
-		row = row[0:idx]
+	// remove comment
+	if idx := strings.IndexRune(text, '#'); idx >= 0 {
+		text = text[0:idx]
 	}
 
-	fields := strings.Split(row, ",")
-
-	// if the first field contains "=", then the row is for variable declaration
-	if strings.Index(fields[0], "=") != -1 {
-		return nil, nil
-	}
-
-	if l := len(fields); l != 3 && l != 4 {
-		return nil, fmt.Errorf("ads.txt has fields length is incorrect.: %s", row)
-	}
-
-	// otherwise the row is valid
-	var r Record
-	r.ExchangeDomain = strings.ToLower(normalize(fields[0]))
-	r.PublisherAccountID = normalize(fields[1])
-	r.AccountType = parseAccountType(normalize(fields[2]))
-	// AuthorityID is optional
-	if len(fields) >= 4 {
-		r.AuthorityID = normalize(fields[3])
-	}
-	return &r, nil
+	return text
 }

--- a/parser.go
+++ b/parser.go
@@ -29,9 +29,12 @@ func (p *Parser) Parse() (*Record, error) {
 		}
 
 		// returns when either is non-nil
-		r, err := parseRecord(text)
-		if r != nil || err != nil {
-			return r, err
+		r, err := parseRow(text)
+		if err != nil {
+			return nil, err
+		}
+		if r != nil && r.Record != nil {
+			return r.Record, nil
 		}
 	}
 

--- a/types.go
+++ b/types.go
@@ -96,7 +96,7 @@ func parseRecord(row string) (*Record, error) {
 	fields := strings.Split(row, ",")
 
 	if l := len(fields); l != 3 && l != 4 {
-		return nil, fmt.Errorf("ads.txt has fields length is incorrect.: %s", row)
+		return nil, fmt.Errorf("ads.txt field length is incorrect: %s", row)
 	}
 
 	// otherwise the row is valid

--- a/types.go
+++ b/types.go
@@ -61,7 +61,11 @@ func parseAccountType(s string) AccountType {
 }
 
 func parseRow(row string) (*Row, error) {
-	if strings.Contains(row, "=") {
+	// Check if "=" exists before the first ","
+	commaIndex := strings.Index(row, ",")
+	equalsIndex := strings.Index(row, "=")
+
+	if equalsIndex != -1 && (commaIndex == -1 || equalsIndex < commaIndex) {
 		// this is a variable declaration
 		v, err := parseVariable(row)
 		if err != nil {

--- a/types.go
+++ b/types.go
@@ -1,0 +1,69 @@
+package adstxt
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Row interface {
+	fmt.Stringer
+}
+
+var (
+	_ Row = (*Record)(nil)
+	_ Row = (*Variable)(nil)
+)
+
+const (
+	AccountDirect AccountType = iota
+	AccountReseller
+	AccountOther
+)
+
+type AccountType int
+
+// Record is ads.txt data field defined in iab.
+type Record struct {
+	// ExchangeDomain is domain name of the advertising system
+	ExchangeDomain string
+
+	// PublisherAccountID is the identifier associated with the seller
+	// or reseller account within the advertising system.
+	PublisherAccountID string
+
+	// AccountType is an enumeration of the type of account.
+	AccountType AccountType
+
+	// AuthorityID is an ID that uniquely identifies the advertising system
+	// within a certification authority.
+	AuthorityID string
+}
+
+func (r *Record) String() string {
+	row := make([]string, 3, 4)
+	row[0] = r.ExchangeDomain
+	row[1] = r.PublisherAccountID
+
+	switch r.AccountType {
+	case AccountDirect:
+		row[2] = "DIRECT"
+	case AccountReseller:
+		row[2] = "RESELLER"
+	}
+
+	if r.AuthorityID != "" {
+		row = append(row, r.AuthorityID)
+	}
+
+	return strings.Join(row, ",")
+}
+
+// Variable is a variable row defined in iab (e.g., contact, subdomain, and such).
+type Variable struct {
+	Key   string
+	Value string
+}
+
+func (v *Variable) String() string {
+	return strings.Join([]string{v.Key, v.Value}, "=")
+}

--- a/types.go
+++ b/types.go
@@ -112,9 +112,20 @@ func parseRecord(row string) (*Record, error) {
 	return &r, nil
 }
 
-// Variable is a variable row defined in iab (e.g., contact, subdomain, and such).
+// Variable represents a variable declaration in the ads.txt specification.
+// Variables are used to provide additional metadata or configuration, such as contact information or subdomain delegation.
+// For example, a variable row in ads.txt might look like:
+//   contact=ads@example.com
+//   subdomain=ads.subdomain.com
+//
+// Key is the variable name (e.g., "contact", "subdomain").
+// Value is the value assigned to the variable (e.g., "ads@example.com", "ads.subdomain.com").
 type Variable struct {
-	Key   string
+	// Key is the variable name in the ads.txt variable declaration.
+	// Example: "contact", "subdomain"
+	Key string
+	// Value is the value assigned to the variable in the ads.txt variable declaration.
+	// Example: "ads@example.com", "ads.subdomain.com"
 	Value string
 }
 

--- a/types.go
+++ b/types.go
@@ -64,14 +64,20 @@ func parseRow(row string) (*Row, error) {
 	if strings.Contains(row, "=") {
 		// this is a variable declaration
 		v, err := parseVariable(row)
-		if v != nil || err != nil {
-			return &Row{Variable: v}, err
+		if err != nil {
+			return nil, err
+		}
+		if v != nil {
+			return &Row{Variable: v}, nil
 		}
 	} else {
 		// this is a record declaration
 		r, err := parseRecord(row)
-		if r != nil || err != nil {
-			return &Row{Record: r}, err
+		if err != nil {
+			return nil, err
+		}
+		if r != nil {
+			return &Row{Record: r}, nil
 		}
 	}
 	return nil, nil

--- a/types.go
+++ b/types.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// Row represents a parsed ads.txt row.
+// Exactly one of Record or Variable will be non-nil when parsing succeeds.
+// Row is nil when an ads.txt row is not a valid row.
 type Row struct {
 	Record   *Record
 	Variable *Variable

--- a/types.go
+++ b/types.go
@@ -95,11 +95,6 @@ func parseRecord(row string) (*Record, error) {
 
 	fields := strings.Split(row, ",")
 
-	// if the first field contains "=", then the row is for variable declaration
-	if strings.Contains(fields[0], "=") {
-		return nil, nil
-	}
-
 	if l := len(fields); l != 3 && l != 4 {
 		return nil, fmt.Errorf("ads.txt has fields length is incorrect.: %s", row)
 	}
@@ -119,8 +114,9 @@ func parseRecord(row string) (*Record, error) {
 // Variable represents a variable declaration in the ads.txt specification.
 // Variables are used to provide additional metadata or configuration, such as contact information or subdomain delegation.
 // For example, a variable row in ads.txt might look like:
-//   contact=ads@example.com
-//   subdomain=ads.subdomain.com
+//
+//	contact=ads@example.com
+//	subdomain=ads.subdomain.com
 //
 // Key is the variable name (e.g., "contact", "subdomain").
 // Value is the value assigned to the variable (e.g., "ads@example.com", "ads.subdomain.com").

--- a/types.go
+++ b/types.go
@@ -14,14 +14,13 @@ type Row struct {
 	Variable *Variable
 }
 
+type AccountType int
+
 const (
 	AccountDirect AccountType = iota
 	AccountReseller
 	AccountOther
 )
-
-type AccountType int
-
 // Record is ads.txt data field defined in iab.
 type Record struct {
 	// ExchangeDomain is domain name of the advertising system

--- a/types_test.go
+++ b/types_test.go
@@ -70,6 +70,18 @@ func TestParseRow(t *testing.T) {
 			},
 		},
 		{
+			"a record row with extension ; should drop extension",
+			"example.com,pub123,RESELLER,auth456;some extension data",
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "pub123",
+					AccountType:        AccountReseller,
+					AuthorityID:        "auth456",
+				},
+			},
+		},
+		{
 			"a variable row",
 			"contact=foo=bar=buz",
 			&Row{

--- a/types_test.go
+++ b/types_test.go
@@ -1,6 +1,67 @@
 package adstxt
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseRow(t *testing.T) {
+	cases := []struct {
+		title    string
+		input    string
+		expected Row
+	}{
+		{
+			"a direct record row",
+			"hoge,fuga,DIRECT",
+			&Record{
+				ExchangeDomain:     "hoge",
+				PublisherAccountID: "fuga",
+				AccountType:        AccountDirect,
+			},
+		},
+		{
+			"a reseller record row",
+			"hoge,fuga,RESELLER",
+			&Record{
+				ExchangeDomain:     "hoge",
+				PublisherAccountID: "fuga",
+				AccountType:        AccountReseller,
+			},
+		},
+		{
+			"a record row with optional AuthorityID",
+			"hoge,fuga,DIRECT,123456",
+			&Record{
+				ExchangeDomain:     "hoge",
+				PublisherAccountID: "fuga",
+				AccountType:        AccountDirect,
+				AuthorityID:        "123456",
+			},
+		},
+		{
+			"a variable row",
+			"contact=foo=bar=buz",
+			&Variable{
+				"contact",
+				"foo=bar=buz",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			r, err := parseRow(c.input)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			if d := cmp.Diff(c.expected, r); d != "" {
+				t.Errorf("mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
 
 func TestRow(t *testing.T) {
 	cases := []struct {

--- a/types_test.go
+++ b/types_test.go
@@ -47,6 +47,29 @@ func TestParseRow(t *testing.T) {
 			},
 		},
 		{
+			"a record row with = in PublisherAccountID",
+			"example.com,pub=123,DIRECT",
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "pub=123",
+					AccountType:        AccountDirect,
+				},
+			},
+		},
+		{
+			"a record row with = in AuthorityID",
+			"example.com,12345,DIRECT,auth=xyz",
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "example.com",
+					PublisherAccountID: "12345",
+					AccountType:        AccountDirect,
+					AuthorityID:        "auth=xyz",
+				},
+			},
+		},
+		{
 			"a variable row",
 			"contact=foo=bar=buz",
 			&Row{

--- a/types_test.go
+++ b/types_test.go
@@ -10,42 +10,50 @@ func TestParseRow(t *testing.T) {
 	cases := []struct {
 		title    string
 		input    string
-		expected Row
+		expected *Row
 	}{
 		{
 			"a direct record row",
 			"hoge,fuga,DIRECT",
-			&Record{
-				ExchangeDomain:     "hoge",
-				PublisherAccountID: "fuga",
-				AccountType:        AccountDirect,
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "hoge",
+					PublisherAccountID: "fuga",
+					AccountType:        AccountDirect,
+				},
 			},
 		},
 		{
 			"a reseller record row",
 			"hoge,fuga,RESELLER",
-			&Record{
-				ExchangeDomain:     "hoge",
-				PublisherAccountID: "fuga",
-				AccountType:        AccountReseller,
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "hoge",
+					PublisherAccountID: "fuga",
+					AccountType:        AccountReseller,
+				},
 			},
 		},
 		{
 			"a record row with optional AuthorityID",
 			"hoge,fuga,DIRECT,123456",
-			&Record{
-				ExchangeDomain:     "hoge",
-				PublisherAccountID: "fuga",
-				AccountType:        AccountDirect,
-				AuthorityID:        "123456",
+			&Row{
+				Record: &Record{
+					ExchangeDomain:     "hoge",
+					PublisherAccountID: "fuga",
+					AccountType:        AccountDirect,
+					AuthorityID:        "123456",
+				},
 			},
 		},
 		{
 			"a variable row",
 			"contact=foo=bar=buz",
-			&Variable{
-				"contact",
-				"foo=bar=buz",
+			&Row{
+				Variable: &Variable{
+					"contact",
+					"foo=bar=buz",
+				},
 			},
 		},
 	}
@@ -58,60 +66,6 @@ func TestParseRow(t *testing.T) {
 			}
 			if d := cmp.Diff(c.expected, r); d != "" {
 				t.Errorf("mismatch (-want +got):\n%s", d)
-			}
-		})
-	}
-}
-
-func TestRow(t *testing.T) {
-	cases := []struct {
-		title     string
-		item      Row
-		expectedd string
-	}{
-		{
-			"DIRECT record",
-			&Record{
-				ExchangeDomain:     "example.com",
-				PublisherAccountID: "123",
-				AccountType:        AccountDirect,
-			},
-			"example.com,123,DIRECT",
-		},
-		{
-			"RESELLER record",
-			&Record{
-				ExchangeDomain:     "example.com",
-				PublisherAccountID: "123",
-				AccountType:        AccountReseller,
-			},
-			"example.com,123,RESELLER",
-		},
-		{
-			"a record with optional AuthorityID",
-			&Record{
-				ExchangeDomain:     "example.com",
-				PublisherAccountID: "123",
-				AccountType:        AccountDirect,
-				AuthorityID:        "TAGID123",
-			},
-			"example.com,123,DIRECT,TAGID123",
-		},
-		{
-			"a variable",
-			&Variable{
-				"contact",
-				"foo@example.com",
-			},
-			"contact=foo@example.com",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.title, func(t *testing.T) {
-			actual := c.item.String()
-			if c.expectedd != actual {
-				t.Errorf("expected %q, but got %q", c.expectedd, actual)
 			}
 		})
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,57 @@
+package adstxt
+
+import "testing"
+
+func TestRow(t *testing.T) {
+	cases := []struct {
+		title     string
+		item      Row
+		expectedd string
+	}{
+		{
+			"DIRECT record",
+			&Record{
+				ExchangeDomain:     "example.com",
+				PublisherAccountID: "123",
+				AccountType:        AccountDirect,
+			},
+			"example.com,123,DIRECT",
+		},
+		{
+			"RESELLER record",
+			&Record{
+				ExchangeDomain:     "example.com",
+				PublisherAccountID: "123",
+				AccountType:        AccountReseller,
+			},
+			"example.com,123,RESELLER",
+		},
+		{
+			"a record with optional AuthorityID",
+			&Record{
+				ExchangeDomain:     "example.com",
+				PublisherAccountID: "123",
+				AccountType:        AccountDirect,
+				AuthorityID:        "TAGID123",
+			},
+			"example.com,123,DIRECT,TAGID123",
+		},
+		{
+			"a variable",
+			&Variable{
+				"contact",
+				"foo@example.com",
+			},
+			"contact=foo@example.com",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			actual := c.item.String()
+			if c.expectedd != actual {
+				t.Errorf("expected %q, but got %q", c.expectedd, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add capability to parse a variable row which has been introduced in Adstxt version 1.0.1 [^1].

- Deprecate current `Parse` method that returns `Record` type only
- Add a new `ParseRow` method that returns a `Row` with one of `Record` or `Variable` types as fields

[^1]: https://iabtechlab.com/ads-txt/